### PR TITLE
[Fixed 0.3 Breaking Change] - Account for custom regex with single group (backward compat)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,8 +34,17 @@ Enables debug mode compilation.
 
 #### includeRegexp
 Type: `RegExp`
+Default: `/^(\s*)include\s+"(\S+)"\s*$/`
+Matches: `include "some/file.html"`
 
-Sets the regular expression used to find *include* statements. The file path should always be the `$1`.
+Sets the regular expression used to find *include* statements.
+
+A regex group is used to identify the important parts of the include statement.  When constructing your own regex, it can contain up to two groups (denoted by parentheses `()` in the regular expression):
+
+ 1. The indentation whitespace to be appended to the front of the included file's contents
+ 2. The file location
+
+**All regular expressions used must contain at least one group.**  If only one group is used, it will be assumed to contain the file path.
 
 ## Usage
 

--- a/tasks/includes.js
+++ b/tasks/includes.js
@@ -135,7 +135,7 @@ module.exports = function(grunt) {
    */
 
   function recurse(p, opts, included, indents) {
-    var src, next, match, error, comment, newline, compiled;
+    var src, next, match, error, comment, newline, compiled, indent, fileLocation;
 
     indents = indents || '';
     comment = commentStyle(p);
@@ -187,8 +187,16 @@ module.exports = function(grunt) {
        */
 
       if(match) {
-        next = path.join(path.dirname(p), match[2]);
-        line = recurse(next, opts, included, indents + match[1]);
+        fileLocation = match[2];
+        indent = match[1];
+
+        if (!fileLocation) {
+          fileLocation = indent;
+          indent = '';
+        }
+
+        next = path.join(path.dirname(p), fileLocation);
+        line = recurse(next, opts, included, indents + indent);
 
         /**
          * Include debug comments if `opts.debug`


### PR DESCRIPTION
A breaking change was introduced in 0.3 which changes the way custom regular expressions work.

Previously, a regex using a single group, for example,  `/^\/\/\+\s*include\s+['"]?([^'"]+)['"]?\s*$/`, would work without issue.  The breaking change was the introduction of another group to the regex for indentation first, meaning that the file name (`match[2]`) becomes undefined.

This pull addresses that by defaulting to `match[1]` being the indent and `match[2]` being the file location, but if file location is undefined it'll use `match[1]` instead.  This preserves the new functionality of indentation and is backwards compatible.
