### PR TITLE
Remove double newline on debug

### DIFF
--- a/tasks/includes.js
+++ b/tasks/includes.js
@@ -215,7 +215,7 @@ module.exports = function(grunt) {
         // Include debug comments if `opts.debug`
         if(opts.debug) {
           line = comment.replace(/%s/g, 'Begin: ' + next) +
-                 newline + line + newline + comment.replace(/%s/g, 'End: ' + next);
+                 newline + line + comment.replace(/%s/g, 'End: ' + next);
         }
       }
 


### PR DESCRIPTION
When debug mode is active and a file properly terminated with a newline is included, an extra empty line appears before the "End:" closing comment.

With this patch, no extra blank line will be inserted.

If the included file does not terminate with an empty line, the debug "End:" comment will appear just after the included content, which is both appropriate (to show that there isn't a newline) and harmless.
