### PR TITLE
Allow end user to specify file suffix in include statement.

### DIFF
--- a/tasks/includes.js
+++ b/tasks/includes.js
@@ -195,6 +195,15 @@ module.exports = function(grunt) {
           indent = '';
         }
 
+        // do not provide a filenameSuffix if one has been given by the include
+        // this allows the end user to specify a suffix to overwrite the default
+        // given in the gruntfile in special cases
+        var suffix = opts.filenameSuffix;
+        if( fileLocation.split('.').length > 1 )
+        {
+          suffix = '';
+        }
+
         fileLocation = opts.filenamePrefix + fileLocation + opts.filenameSuffix;
         next = path.join((opts.includePath || path.dirname(p)), fileLocation);
         content = recurse(next, opts, included, indents + indent);


### PR DESCRIPTION
Do not pass in filenameSuffix specified in the Gruntfile when a suffix has been given by the include statement.

```js
// Build the site using grunt-includes
    includes: {
      haml: {
        options: {
          filenameSuffix: ".html",
        }
      }
    }
```

Given the above config, this would fail ( given the default .html suffix ), but the PR fixes this.
```html
<!-- include header.haml -->
```
