### PR TITLE
Small fix: in silent mode and remove duplicates, don't log errors

### DIFF
--- a/tasks/includes.js
+++ b/tasks/includes.js
@@ -166,7 +166,9 @@ module.exports = function(grunt) {
     // If `opts.duplicates` is false and file has been included, error
     if(!opts.duplicates && ~included.indexOf(p)) {
       error = 'Duplicate include: ' + p + ' skipping.';
-      grunt.log.error(error);
+      if (!opts.silent) {
+         grunt.log.error(error);
+      }
 
       if(opts.debug) {
         return comment.replace(/%s/g, error);


### PR DESCRIPTION
Hello,
I'm using this library to resolve includes in LESS files and produce a pre-processed file. It works seamlessly!
However I'm forced to enable the 'duplicates' flag to avoid recursive output (LESS is doing it automatically). In that case, the output is tampered by a lot of errors (actually warnings).
With this fix, using "silent" will remove these lines from the output.

Thank you,
 Luciano